### PR TITLE
解决容器运行时权限问题

### DIFF
--- a/DOCKER_PERMISSIONS.md
+++ b/DOCKER_PERMISSIONS.md
@@ -1,0 +1,155 @@
+# Docker权限配置说明
+
+## 概述
+
+本项目已优化Docker权限配置，支持动态用户ID，解决了在非特权容器环境下的权限问题。
+
+## 新增功能
+
+### 动态用户ID支持
+
+现在支持通过环境变量动态设置容器内运行用户的UID和GID，避免主机与容器用户ID不匹配的问题。
+
+### 环境变量
+
+- `PUID`: 设置容器内运行用户的UID（默认：1001）
+- `PGID`: 设置容器内运行用户的GID（默认：1001）
+
+## 使用方法
+
+### 1. 使用默认用户（UID=1001）
+
+```bash
+docker run -d \
+  --name areyouok \
+  -p 3000:3000 \
+  -v $(pwd)/data:/app/data \
+  areyouok:latest
+```
+
+### 2. 使用自定义用户ID
+
+```bash
+docker run -d \
+  --name areyouok \
+  -p 3000:3000 \
+  -v $(pwd)/data:/app/data \
+  -e PUID=1000 \
+  -e PGID=1000 \
+  areyouok:latest
+```
+
+### 3. 匹配主机用户
+
+```bash
+# 获取当前用户的UID和GID
+HOST_UID=$(id -u)
+HOST_GID=$(id -g)
+
+docker run -d \
+  --name areyouok \
+  -p 3000:3000 \
+  -v $(pwd)/data:/app/data \
+  -e PUID=$HOST_UID \
+  -e PGID=$HOST_GID \
+  areyouok:latest
+```
+
+### 4. Docker Compose配置
+
+```yaml
+version: '3.8'
+services:
+  areyouok:
+    image: areyouok:latest
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./data:/app/data
+      - ./logs:/app/logs
+    environment:
+      - PUID=1000  # 根据需要修改
+      - PGID=1000  # 根据需要修改
+    restart: unless-stopped
+```
+
+## 兼容性说明
+
+### 向后兼容
+
+- **完全兼容**：现有的start.sh和stop.sh脚本无需任何修改
+- **无影响**：不设置PUID/PGID环境变量时，使用默认UID=1001
+- **平滑升级**：现有容器可以无缝升级到新版本
+
+### 原有脚本保持不变
+
+- `docker-start.sh`: 启动脚本功能完全保留
+- `stop.sh`: 停止脚本功能完全保留
+- 所有原有的功能和配置都得到保留
+
+## 权限处理逻辑
+
+1. **默认情况**：如果未设置PUID/PGID，使用默认的nodejs用户（UID=1001）
+2. **自定义情况**：如果设置了PUID/PGID，动态创建对应UID/GID的用户
+3. **Root运行**：以root用户启动，entrypoint脚本负责用户切换
+4. **权限修复**：自动修复关键目录的用户权限
+
+## 解决的问题
+
+### 1. 主机与容器用户ID不匹配
+- **问题**：容器内创建的文件在主机上显示为未知用户
+- **解决**：通过PUID/PGID匹配主机用户ID
+
+### 2. 挂载目录权限问题
+- **问题**：容器无法写入挂载的主机目录
+- **解决**：动态调整用户权限，确保目录可访问
+
+### 3. 数据持久化问题
+- **问题**：容器重启后数据文件权限混乱
+- **解决**：保持一致的用户权限设置
+
+### 4. 多环境部署困难
+- **问题**：不同环境用户ID分配不同
+- **解决**：通过环境变量灵活配置
+
+## 构建镜像
+
+```bash
+# 构建镜像（使用默认UID=1001）
+docker build -t areyouok:latest .
+
+# 构建镜像（指定自定义UID）
+docker build --build-arg PUID=1000 --build-arg PGID=1000 -t areyouok:latest .
+```
+
+## 故障排除
+
+### 1. 权限被拒绝
+```bash
+# 检查挂载目录权限
+ls -la ./data
+
+# 设置合适的权限
+sudo chown -R $USER:$USER ./data
+sudo chmod -R 755 ./data
+```
+
+### 2. 数据库文件权限问题
+```bash
+# 修复数据库文件权限
+sudo chown $USER:$USER ./data/expense_bills.db
+```
+
+### 3. 日志写入失败
+```bash
+# 确保日志目录有写权限
+mkdir -p ./logs
+chmod 755 ./logs
+```
+
+## 最佳实践
+
+1. **生产环境**：始终明确设置PUID/PGID环境变量
+2. **开发环境**：使用当前用户ID匹配主机权限
+3. **数据持久化**：确保挂载的目录有正确的权限
+4. **监控日志**：检查entrypoint日志确认用户切换成功

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ FROM node:18-alpine AS backend-deps
 WORKDIR /app
 RUN apk add --no-cache sqlite curl && rm -rf /var/cache/apk/*
 COPY backend/package*.json ./
-RUN npm ci --only=production --silent && npm cache clean --force
+RUN npm ci --only=production --silent && npm cache clean --force && ls -la node_modules/
 
 FROM node:18-alpine AS production
 ENV NODE_ENV=production
@@ -32,7 +32,7 @@ WORKDIR /app
 
 COPY backend/ ./backend/
 COPY --from=backend-deps /app/node_modules ./backend/node_modules/
-COPY --from=frontend-builder /app/frontend/dist ./frontend/
+COPY --from=frontend-builder /app/frontend/dist ./frontend/dist/
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY docker-start.sh /app/start.sh
 COPY docker-entrypoint.sh /app/entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,29 +17,35 @@ ENV NODE_ENV=production
 ENV PORT=7965
 ENV TZ=Asia/Shanghai
 
-RUN apk add --no-cache nginx sqlite curl dumb-init && \
+# 设置默认用户ID，可通过环境变量覆盖
+ARG PUID=1001
+ARG PGID=1001
+ENV PUID=${PUID}
+ENV PGID=${PGID}
+
+RUN apk add --no-cache nginx sqlite curl dumb-init su-exec && \
     addgroup -g 1001 -S nodejs && \
     adduser -S nodejs -u 1001 && \
     rm -rf /var/cache/apk/* /tmp/* /var/tmp/*
 
 WORKDIR /app
 
-COPY --chown=nodejs:nodejs backend/ ./backend/
-COPY --from=backend-deps --chown=nodejs:nodejs /app/node_modules ./backend/node_modules/
-COPY --from=frontend-builder --chown=nodejs:nodejs /app/frontend/dist ./frontend/
+COPY backend/ ./backend/
+COPY --from=backend-deps /app/node_modules ./backend/node_modules/
+COPY --from=frontend-builder /app/frontend/dist ./frontend/
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY docker-start.sh /app/start.sh
+COPY docker-entrypoint.sh /app/entrypoint.sh
 
 RUN mkdir -p /app/data /app/logs /var/log/nginx /var/lib/nginx/logs /run/nginx && \
-    chown -R nodejs:nodejs /app /var/log/nginx /var/lib/nginx /etc/nginx /run/nginx && \
     chmod 755 /app/data /app/logs /var/log/nginx /var/lib/nginx /var/lib/nginx/logs /etc/nginx /run/nginx && \
     chmod 644 /etc/nginx/nginx.conf && \
-    chmod +x /app/start.sh
+    chmod +x /app/start.sh /app/entrypoint.sh
 
-USER nodejs
+# 移除USER指令，让entrypoint脚本处理用户切换
 EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
     CMD curl -f http://localhost/health || exit 1
 
-ENTRYPOINT ["dumb-init", "--"]
+ENTRYPOINT ["dumb-init", "--", "/app/entrypoint.sh"]
 CMD ["/app/start.sh"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,20 +6,23 @@ services:
       context: .
       dockerfile: Dockerfile
       target: production
+      args:
+        - PUID=${PUID:-1000}
+        - PGID=${PGID:-1000}
     container_name: areyouok-dev
     ports:
-      - "3000:80"
+      - "53000:3000"
       - "7965:7965"
     environment:
       - NODE_ENV=development
       - PORT=7965
       - TZ=Asia/Shanghai
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
     volumes:
       - ./data:/app/data:rw
       - ./logs:/app/logs:rw
       - ./backend/.env:/app/backend/.env:ro
-      - ./backend:/app/backend:ro
-      - ./frontend:/app/frontend:ro
     networks:
       - areyouok-network
     command: >

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   areyouok:
-    image: areyouok:dev
+    image: pxvp2008/areyouok-app:latest
     container_name: areyouok-app
     restart: unless-stopped
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   areyouok:
-    image: pxvp2008/areyouok-app:latest
+    image: areyouok:dev
     container_name: areyouok-app
     restart: unless-stopped
     ports:
@@ -11,6 +11,9 @@ services:
       - NODE_ENV=production
       - PORT=7965
       - TZ=Asia/Shanghai
+      # 权限配置：动态用户ID设置
+      - PUID=1000
+      - PGID=1000
     volumes:
       - ./data:/app/data:rw
       - ./logs:/app/logs:rw

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+# docker-entrypoint.sh - Docker容器入口点脚本
+# 支持动态用户ID权限调整
+
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] [entrypoint] $*"
+}
+
+# 检查并设置用户权限
+setup_user_permissions() {
+    # 如果以root用户运行，检查是否需要切换用户
+    if [ "$(id -u)" = "0" ]; then
+        # 如果设置了PUID和PGID环境变量，则动态创建用户
+        if [ -n "$PUID" ] && [ -n "$PGID" ]; then
+            log "Setting up user with UID=${PUID} and GID=${PGID}"
+
+            # 检查目标组是否已存在，如果不存在则创建
+            if ! getent group $PGID >/dev/null 2>&1; then
+                addgroup -g $PGID -S nodejs
+            else
+                # 组已存在，获取组名
+                GROUP_NAME=$(getent group $PGID | cut -d: -f1)
+                log "Using existing group: $GROUP_NAME (GID=$PGID)"
+            fi
+
+            # 检查目标用户是否已存在
+            if ! id -u $PUID >/dev/null 2>&1; then
+                # 用户不存在，创建新用户
+                if [ "$GROUP_NAME" = "nodejs" ]; then
+                    adduser -S nodejs -u $PUID -G nodejs -h /app
+                else
+                    adduser -S nodejs -u $PUID -G $GROUP_NAME -h /app
+                fi
+            else
+                # 用户已存在，获取用户名
+                USER_NAME=$(getent passwd $PUID | cut -d: -f1)
+                log "Using existing user: $USER_NAME (UID=$PUID)"
+            fi
+
+            # 设置目录权限
+            chown -R $PUID:$PGID /app /var/log/nginx /var/lib/nginx /etc/nginx /run/nginx 2>/dev/null || true
+
+            # 如果存在数据目录，也要设置权限
+            if [ -d "/app/data" ]; then
+                chown -R $PUID:$PGID /app/data
+            fi
+
+            # 切换到指定用户执行命令
+            log "Switching to user (UID=${PUID}, GID=${PGID})"
+            if command -v su-exec >/dev/null 2>&1; then
+                exec su-exec $PUID:$PGID "$@"
+            else
+                exec setpriv --reuid $PUID --regid $PGID --init-groups "$@"
+            fi
+        else
+            # 没有设置PUID/PGID，使用默认的nodejs用户（UID=1001）
+            log "Using default nodejs user (UID=1001)"
+
+            # 确保nodejs用户存在
+            if ! id nodejs >/dev/null 2>&1; then
+                addgroup -g 1001 -S nodejs
+                adduser -S nodejs -u 1001 -G nodejs -h /app
+                chown -R nodejs:nodejs /app /var/log/nginx /var/lib/nginx /etc/nginx /run/nginx 2>/dev/null || true
+            fi
+
+            if command -v su-exec >/dev/null 2>&1; then
+                exec su-exec nodejs "$@"
+            else
+                exec setpriv --reuid 1001 --regid 1001 --init-groups "$@"
+            fi
+        fi
+    else
+        # 非root用户运行，直接执行命令
+        log "Running as current user (UID=$(id -u), GID=$(id -g))"
+        exec "$@"
+    fi
+}
+
+# 处理信号
+cleanup() {
+    log "Received shutdown signal, cleaning up..."
+    # 如果有子进程需要清理，在这里处理
+    exit 0
+}
+
+trap cleanup SIGTERM SIGINT
+
+# 设置用户权限并执行命令
+setup_user_permissions "$@"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -853,6 +853,7 @@
       "resolved": "https://mirrors.huaweicloud.com/repository/npm/@types/lodash-es/-/lodash-es-4.17.12.tgz",
       "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/lodash": "*"
       }
@@ -947,6 +948,7 @@
       "resolved": "https://mirrors.huaweicloud.com/repository/npm/@vue/runtime-core/-/runtime-core-3.5.24.tgz",
       "integrity": "sha512-RYP/byyKDgNIqfX/gNb2PB55dJmM97jc9wyF3jK7QUInYKypK2exmZMNwnjueWwGceEkP6NChd3D2ZVEp9undQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/reactivity": "3.5.24",
         "@vue/shared": "3.5.24"
@@ -1112,6 +1114,7 @@
       "resolved": "https://mirrors.huaweicloud.com/repository/npm/chart.js/-/chart.js-4.5.1.tgz",
       "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -1171,6 +1174,7 @@
       "resolved": "https://mirrors.huaweicloud.com/repository/npm/echarts/-/echarts-5.6.0.tgz",
       "integrity": "sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "2.3.0",
         "zrender": "5.6.1"
@@ -1455,13 +1459,15 @@
       "version": "4.17.21",
       "resolved": "https://mirrors.huaweicloud.com/repository/npm/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash-es": {
       "version": "4.17.21",
       "resolved": "https://mirrors.huaweicloud.com/repository/npm/lodash-es/-/lodash-es-4.17.21.tgz",
       "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash-unified": {
       "version": "1.0.3",
@@ -1652,6 +1658,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -1711,6 +1718,7 @@
       "resolved": "https://mirrors.huaweicloud.com/repository/npm/vue/-/vue-3.5.24.tgz",
       "integrity": "sha512-uTHDOpVQTMjcGgrqFPSb8iO2m1DUvo+WbGqoXQz8Y1CeBYQ0FXf2z1gLRaBtHjlRz7zZUBHxjVB5VTLzYkvftg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.24",
         "@vue/compiler-sfc": "3.5.24",

--- a/nginx.conf
+++ b/nginx.conf
@@ -74,7 +74,7 @@ http {
     server {
         listen 3000;
         server_name localhost;
-        root /app/frontend;
+        root /app/frontend/dist;
         index index.html;
 
         # Security headers


### PR DESCRIPTION
解决容器运行时权限问题 #2

This pull request introduces a major improvement to Docker permissions handling for the project, enabling dynamic user ID configuration for containers. This update solves common permission issues when mounting host directories and makes deployments more flexible and robust across different environments. The changes include a new entrypoint script, Dockerfile and Compose updates, and comprehensive documentation.

**Docker Permissions & User Management**

* Added `docker-entrypoint.sh` script to dynamically set container user/group IDs based on `PUID`/`PGID` environment variables, ensuring correct file permissions and seamless user switching; falls back to default user if not set.
* Updated `Dockerfile` to support dynamic user IDs via build args and environment variables, removed the static `USER` instruction, and set the entrypoint to the new script for runtime permission handling. Also added `su-exec` for user switching.
* Modified `docker-compose.yml` and `docker-compose.dev.yml` to pass `PUID`/`PGID` as build args and environment variables, allowing per-environment user configuration. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R14-R16) [[2]](diffhunk://#diff-9542f82d64bbeebd91f6236324bfe199e9657e2cb1fd9779d5d6dcdcf9cd4de1R9-L22)
* Added `DOCKER_PERMISSIONS.md` documentation detailing the new dynamic user ID feature, usage instructions, troubleshooting, and best practices for permissions.

**Frontend & Nginx Adjustments**

* Changed nginx `root` directive to point to `/app/frontend/dist` to match frontend build output location.

**Frontend Dependency Metadata**

* Marked several dependencies in `frontend/package-lock.json` as `peer` dependencies for improved package management and compatibility. [[1]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR856) [[2]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR951) [[3]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR1117) [[4]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR1177) [[5]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aL1458-R1470) [[6]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR1661) [[7]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR1721)